### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.juk.json
+++ b/org.kde.juk.json
@@ -16,6 +16,15 @@
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=org.kde.kglobalaccel"
     ],
+     "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name": "phonon",


### PR DESCRIPTION
The installed size reduced from 21.8 MB to 17.7 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.